### PR TITLE
Don't attempt to parse a file if the key already exists in the metadata, even if the file is missing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,19 +35,21 @@ function plugin(opts){
       var file = opts[key];
       var ext = extname(file);
       if (!~exts.indexOf(ext)) throw new Error('unsupported metadata type "' + ext + '"');
-      if (!files[file]) throw new Error('file "' + file + '" not found');
+      if (!metadata[key] || files[file]) {
+        if (!files[file]) throw new Error('file "' + file + '" not found');
 
-      var parse = parsers[ext];
-      var str = files[file].contents.toString();
-      delete files[file];
+        var parse = parsers[ext];
+        var str = files[file].contents.toString();
+        delete files[file];
 
-      try {
-        var data = parse(str);
-      } catch (e) {
-        return done(new Error('malformed data in "' + file + '"'));
+        try {
+          var data = parse(str);
+        } catch (e) {
+          return done(new Error('malformed data in "' + file + '"'));
+        }
+
+        metadata[key] = data;
       }
-
-      metadata[key] = data;
     }
 
     done();

--- a/test/fixtures/duplicate/src/data.json
+++ b/test/fixtures/duplicate/src/data.json
@@ -1,0 +1,3 @@
+{
+  "string": "string"
+}

--- a/test/fixtures/duplicate/src/data2.json
+++ b/test/fixtures/duplicate/src/data2.json
@@ -1,0 +1,3 @@
+{
+  "string": "string2"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,18 @@ describe('metalsmith-metadata', function(){
     });
   });
 
+  it('should not parse a file if the key already exists in the metadata', function(done){
+    var m = Metalsmith('test/fixtures/json')
+      .use(metadata({ file: 'data.json' }))
+      .use(metadata({ file: 'missing.json' }));
+    m.build(function(err){
+      if (err) return done(err);
+      assert.deepEqual(m.metadata().file, { string: 'string' });
+      assert(!exists('test/fixtures/json/build'));
+      done();
+    });
+  });
+
   it('should parse YAML', function(done){
     var m = Metalsmith('test/fixtures/yaml').use(metadata({ file: 'data.yaml' }));
     m.build(function(err){

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,18 @@ describe('metalsmith-metadata', function(){
     });
   });
 
+  it('should parse a file even if the key exists if the file is in the bundle', function(done){
+    var m = Metalsmith('test/fixtures/duplicate')
+      .use(metadata({ file: 'data.json' }))
+      .use(metadata({ file: 'data2.json' }));
+    m.build(function(err){
+      if (err) return done(err);
+      assert.deepEqual(m.metadata().file, { string: 'string2' });
+      assert(!exists('test/fixtures/json/build'));
+      done();
+    });
+  });
+
   it('should parse YAML', function(done){
     var m = Metalsmith('test/fixtures/yaml').use(metadata({ file: 'data.yaml' }));
     m.build(function(err){


### PR DESCRIPTION
When using metalsmith-metadata with watchers like watch() or browserSync() that perform partial rebuilds of content, the plugin throws errors because the json/yaml files it's looking for aren't part of the partial bundle of files. However, in these cases, we're generally ok, because the work has already been done and the key exists in the metadata already.

This pull request makes it so the plugin passes safely in this case, while still parsing and proceeding with overwriting an existing key if the json/yaml file in question is in the file list passed to it. It also adds tests for this behavior.