### PR TITLE
Normalize file path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 
-var extname = require('path').extname;
+var path = require('path');
 var yaml = require('js-yaml');
 
 /**
@@ -32,8 +32,8 @@ function plugin(opts){
     var exts = Object.keys(parsers);
 
     for (var key in opts) {
-      var file = opts[key];
-      var ext = extname(file);
+      var file = path.normalize(opts[key]);
+      var ext = path.extname(file);
       if (!~exts.indexOf(ext)) throw new Error('unsupported metadata type "' + ext + '"');
       if (!files[file]) throw new Error('file "' + file + '" not found');
 


### PR DESCRIPTION
Allows data files to be loaded from folders within the metalsmith source folder

``` json
 "plugins": {
    "metalsmith-metadata": {
      "mydata": "myfolder/mydata.yaml"
    }
}
```
