### PR TITLE
Allow .yml as file extension for YAML as well

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ module.exports = plugin;
 
 var parsers = {
   '.json': JSON.parse,
-  '.yaml': yaml.safeLoad
+  '.yaml': yaml.safeLoad,
+  '.yml': yaml.safeLoad
 };
 
 /**


### PR DESCRIPTION
.yml is a valid extensions for YAML files, so it should be supported as well.