### PR TITLE
Allow metadata from an external file source not in 'src'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,8 +17,10 @@
 {
   "plugins": {
     "metalsmith-metadata": {
-      "authors": "./path/to/authors.json",
-      "categories": "./path/to/categories.yaml"
+      "files": {
+        "authors": "./path/to/authors.json",
+        "categories": "./path/to/categories.yaml"
+      }
     }
   }
 }
@@ -32,18 +34,24 @@
 var metadata = require('metalsmith-metadata');
 
 metalsmith.use(metadata({
-  authors: './path/to/authors.json',
-  categories: './path/to/categories.yaml'
+  "files": {
+    authors: './path/to/authors.json',
+    categories: './path/to/categories.yaml'
+  }
 }));
 ```
 
-Note that the path is relative to the Metalsmith source directory (`src`). To use a file outside of src, pass "true" as a second argument:
+Note that the path is relative to the Metalsmith source directory (`src`). To use a file outside of src, add the following configuration:
 
 ```js
 metalsmith.use(metadata({
-  authors: './path/to/authors.json',
-  categories: './path/to/categories.yaml'
-}, true ));
+  "files": {
+    authors: '../path/to/authors.json',
+    categories: '/abs/path/to/categories.yaml'
+  },
+  "config": {
+    isExternalSrc: true
+  }}));
 ```
 
 ## License

--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,15 @@ metalsmith.use(metadata({
 }));
 ```
 
+Note that the path is relative to the Metalsmith source directory (`src`). To use a file outside of src, pass "true" as a second argument:
+
+```js
+metalsmith.use(metadata({
+  authors: './path/to/authors.json',
+  categories: './path/to/categories.yaml'
+}, true ));
+```
+
 ## License
 
   MIT

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,25 +26,26 @@ var parsers = {
  * @return {Function}
  */
 
-function plugin(opts, externalSrc){
+function plugin(opts){
   opts = opts || {};
-  externalSrc = externalSrc || false;
+  config = opts.config || {};
+  dataFiles = opts.files || {};
 
   return function(files, metalsmith, done){
     var metadata = metalsmith.metadata();
     var exts = Object.keys(parsers);
 
-    for (var key in opts) {
-      var file = path.normalize(opts[key]);
+    for (var key in dataFiles) {
+      var file = path.normalize(dataFiles[key]);
       var ext = path.extname(file);
       if (!~exts.indexOf(ext)) throw new Error('unsupported metadata type "' + ext + '"');
-      if (!externalSrc && !files[file]) throw new Error(
+      if (!config.isExternalSrc && !files[file]) throw new Error(
         'file "' + file + '" not found in Metalsmith source: ' + metalsmith._source
       );
 
       var parse = parsers[ext];
 
-      if (!externalSrc) {
+      if (!config.isExternalSrc) {
         var str = files[file].contents.toString();
         delete files[file];
       } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 
-var extname = require('path').extname;
 var yaml = require('js-yaml');
+var fs = require('fs');
+var path = require('path');
 
 /**
  * Expose `plugin`.
@@ -19,28 +20,36 @@ var parsers = {
 };
 
 /**
- * Metalsmith plugin to hide drafts from the output.
+ * Metalsmith plugin to load metadata from files.
  *
  * @param {Object} opts
  * @return {Function}
  */
 
-function plugin(opts){
+function plugin(opts, externalSrc){
   opts = opts || {};
+  externalSrc = externalSrc || false;
 
   return function(files, metalsmith, done){
     var metadata = metalsmith.metadata();
     var exts = Object.keys(parsers);
 
     for (var key in opts) {
-      var file = opts[key];
-      var ext = extname(file);
+      var file = path.normalize(opts[key]);
+      var ext = path.extname(file);
       if (!~exts.indexOf(ext)) throw new Error('unsupported metadata type "' + ext + '"');
-      if (!files[file]) throw new Error('file "' + file + '" not found');
+      if (!externalSrc && !files[file]) throw new Error(
+        'file "' + file + '" not found in Metalsmith source: ' + metalsmith._source
+      );
 
       var parse = parsers[ext];
-      var str = files[file].contents.toString();
-      delete files[file];
+
+      if (!externalSrc) {
+        var str = files[file].contents.toString();
+        delete files[file];
+      } else {
+        var str = fs.readFileSync(file).toString();
+      }
 
       try {
         var data = parse(str);

--- a/test/fixtures/altpath/data.json
+++ b/test/fixtures/altpath/data.json
@@ -1,0 +1,3 @@
+{
+  "string": "string"
+}

--- a/test/fixtures/subdir/src/path/to/file/data.json
+++ b/test/fixtures/subdir/src/path/to/file/data.json
@@ -1,0 +1,3 @@
+{
+  "string": "string"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -34,4 +34,28 @@ describe('metalsmith-metadata', function(){
       done();
     });
   });
+
+  it('should load from a normalized subdirectory path', function(done){
+    var m = Metalsmith('test/fixtures/subdir').use(metadata({ files: {file: './path/to/file/data.json'} }));
+    m.build(function(err){
+      if (err) return done(err);
+      assert.deepEqual(m.metadata().file, { string: 'string' });
+      assert(!exists('test/fixtures/subdir/build'));
+      done();
+    });
+  });
+
+  it('should load from an external directory path', function(done){
+    var m = Metalsmith('test/fixtures/altpath').use(metadata({
+      files: { file: 'test/fixtures/altpath/data.json'},
+      config: { isExternalSrc: true }
+    }));
+    m.build(function(err){
+      if (err) return done(err);
+      assert.deepEqual(m.metadata().file, { string: 'string' });
+      assert(!exists('test/fixtures/altpath/build'));
+      done();
+    });
+  });
+
 });

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ var metadata = require('..');
 
 describe('metalsmith-metadata', function(){
   it('should error for malformed data', function(done){
-    var m = Metalsmith('test/fixtures/malformed').use(metadata({ file: 'data.json' }));
+    var m = Metalsmith('test/fixtures/malformed').use(metadata({ files: {file: 'data.json'} }));
     m.build(function(err){
       assert(err);
       assert(~err.message.indexOf('malformed data'));
@@ -16,7 +16,7 @@ describe('metalsmith-metadata', function(){
   });
 
   it('should parse JSON', function(done){
-    var m = Metalsmith('test/fixtures/json').use(metadata({ file: 'data.json' }));
+    var m = Metalsmith('test/fixtures/json').use(metadata({ files: {file: 'data.json'} }));
     m.build(function(err){
       if (err) return done(err);
       assert.deepEqual(m.metadata().file, { string: 'string' });
@@ -26,7 +26,7 @@ describe('metalsmith-metadata', function(){
   });
 
   it('should parse YAML', function(done){
-    var m = Metalsmith('test/fixtures/yaml').use(metadata({ file: 'data.yaml' }));
+    var m = Metalsmith('test/fixtures/yaml').use(metadata({ files: {file: 'data.yaml'} }));
     m.build(function(err){
       if (err) return done(err);
       assert.deepEqual(m.metadata().file, { string: 'string' });


### PR DESCRIPTION
So I've made a couple tweaks to the metadata plugin that I think might be helpful moving forward. However, it required adding some additional config which meant restructuring the arguments passed in (which therefore introduces a breaking change).
- I believe this includes the code that was changed in (https://github.com/segmentio/metalsmith-metadata/pull/11)
- I believe this addresses some of the issues folks are experiencing in this issue (https://github.com/segmentio/metalsmith-metadata/issues/5).

I was advised that it might be worth including a changelog and to bump the major version too, although I think some projects prefer to handle those sorts of additions manually? I have a separate branch for that also and would be happy to merge / send a PR for that also if you'd like. (https://github.com/JemBijoux/metalsmith-metadata/tree/add-changelog-bump-version)
