### PR TITLE
Nested config files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,6 @@ function plugin(opts){
   return function(files, metalsmith, done){
     var metadata = metalsmith.metadata();
     var exts = Object.keys(parsers);
-
     for (var key in opts) {
       var file = opts[key].replace(/(\/|\\)/g, path.sep);
       var ext = extname(file);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
-
-var extname = require('path').extname;
+var path = require('path');
+var extname = path.extname;
 var yaml = require('js-yaml');
 
 /**
@@ -33,7 +33,7 @@ function plugin(opts){
     var exts = Object.keys(parsers);
 
     for (var key in opts) {
-      var file = opts[key];
+      var file = opts[key].replace(/(\/|\\)/g, path.sep);
       var ext = extname(file);
       if (!~exts.indexOf(ext)) throw new Error('unsupported metadata type "' + ext + '"');
       if (!metadata[key] || files[file]) {

--- a/test/fixtures/deep-nested/src/path/path/data.yaml
+++ b/test/fixtures/deep-nested/src/path/path/data.yaml
@@ -1,0 +1,1 @@
+string: 'string'

--- a/test/fixtures/nested/src/path/data.yaml
+++ b/test/fixtures/nested/src/path/data.yaml
@@ -1,0 +1,1 @@
+string: 'string'

--- a/test/index.js
+++ b/test/index.js
@@ -58,4 +58,34 @@ describe('metalsmith-metadata', function(){
       done();
     });
   });
+
+  it('should parse nested path', function(done){
+    var m = Metalsmith('test/fixtures/nested').use(metadata({ file: 'path/data.yaml' }));
+    m.build(function(err){
+      if (err) return done(err);
+      assert.deepEqual(m.metadata().file, { string: 'string' });
+      assert(!exists('test/fixtures/nested/build'));
+      done();
+    });
+  });
+
+  it('should parse nested path with backslash', function(done){
+    var m = Metalsmith('test/fixtures/nested').use(metadata({ file: 'path\\data.yaml' }));
+    m.build(function(err){
+      if (err) return done(err);
+      assert.deepEqual(m.metadata().file, { string: 'string' });
+      assert(!exists('test/fixtures/nested/build'));
+      done();
+    });
+  });
+
+  it('should parse deep nested path', function(done){
+    var m = Metalsmith('test/fixtures/deep-nested').use(metadata({ file: 'path/path/data.yaml' }));
+    m.build(function(err){
+      if (err) return done(err);
+      assert.deepEqual(m.metadata().file, { string: 'string' });
+      assert(!exists('test/fixtures/deep-nested/build'));
+      done();
+    });
+  });
 });


### PR DESCRIPTION
This patch aims to fix the difference between Windows and *nix path seperator.

I tested it on Windows myself. I used Travis for Linux. You can see test result [here](https://travis-ci.org/thangngoc89/metalsmith-metadata/builds/92902050) ( `.travis.yml` is in a different branch. It won't appear in this pull request )

